### PR TITLE
ci: add kustomize diff artifact workflow

### DIFF
--- a/.github/workflows/kustomize-diff-artifact.yml
+++ b/.github/workflows/kustomize-diff-artifact.yml
@@ -1,0 +1,31 @@
+# Kustomize Diff (Artifact Mode) - Generate HTML diff of rendered manifests
+name: Kustomize Diff (Artifact)
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'clusters/**'
+      - 'components/**'
+      - 'charts/**'
+      - 'configs/**'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  kustomize-diff:
+    name: Rendered Manifest Diff
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate diff
+        uses: mgazza/kustomize-roots@v1
+        with:
+          mode: artifact
+          exclude: ".git src scripts docs tests"


### PR DESCRIPTION
## Summary
- Adds rendered manifest diff reporting on PRs via `kustomize-roots@v1`
- Shows inline diff in PR comment with collapsible `<details>` block
- Publishes interactive HTML diff report to GitHub Pages (clickable link in PR comment)

## Setup required
- Enable GitHub Pages in repo Settings > Pages > Source: `gh-pages` branch (the action creates the branch automatically)

## Test plan
- [ ] Open a PR that changes `clusters/` or `components/` files
- [ ] Verify PR comment appears with inline diff and Pages link

🤖 Generated with [Claude Code](https://claude.com/claude-code)